### PR TITLE
Uses package.json repo for installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "stephenmathieson/path-join.c": "0.0.6",
     "strdup": "0.0.0",
     "stephenmathieson/parse-repo.c": "1.1.1",
-    "logger": "0.0.0",
+    "logger": "0.0.1",
     "stephenmathieson/debug.c": "0.0.0"
   },
   "development": {

--- a/src/clib-package.c
+++ b/src/clib-package.c
@@ -32,6 +32,8 @@
 #define DEFAULT_REPO_OWNER "clibs"
 #endif
 
+#define GITHUB_CONTENT_URL "https://raw.githubusercontent.com/"
+
 debug_t _debugger;
 
 #define _debug(...) ({                                         \
@@ -357,7 +359,6 @@ clib_package_new_from_slug(const char *slug, int verbose) {
   if (!(version = parse_repo_version(slug, DEFAULT_REPO_VERSION))) goto error;
   if (!(url = clib_package_url(author, name, version))) goto error;
   if (!(json_url = clib_package_file_url(url, "package.json"))) goto error;
-  if (!(repo = clib_package_repo(author, name))) goto error;
 
   _debug("author: %s", author);
   _debug("name: %s", name);
@@ -386,12 +387,15 @@ clib_package_new_from_slug(const char *slug, int verbose) {
 
   // force version number
   if (pkg->version) {
-    if (0 != strcmp(version, pkg->version)) {
-      _debug("forcing version number: %s (%s)", version, pkg->version);
-      free(pkg->version);
-      pkg->version = version;
-    } else {
-      free(version);
+    if (version)
+    {
+      if (0 != strcmp(version, DEFAULT_REPO_VERSION)) {
+        _debug("forcing version number: %s (%s)", version, pkg->version);
+        free(pkg->version);
+        pkg->version = version;
+      } else {
+        free(version);
+      }
     }
   } else {
     pkg->version = version;
@@ -409,14 +413,16 @@ clib_package_new_from_slug(const char *slug, int verbose) {
     pkg->author = author;
   }
 
-  // force package repo
+  if (!(repo = clib_package_repo(pkg->author, pkg->name))) goto error;
+
   if (pkg->repo) {
     if (0 != strcmp(repo, pkg->repo)) {
-      free(pkg->repo);
-      pkg->repo = repo;
-    } else {
-      free(repo);
+      free(url);
+      if (!(url = clib_package_url_from_repo(pkg->repo, pkg->version)))
+        goto error;
     }
+    free(repo);
+    repo = NULL;
   } else {
     pkg->repo = repo;
   }
@@ -444,7 +450,7 @@ char *
 clib_package_url(const char *author, const char *name, const char *version) {
   if (!author || !name || !version) return NULL;
   int size =
-      34 // https://raw.githubusercontent.com/
+      strlen(GITHUB_CONTENT_URL)
     + strlen(author)
     + 1 // /
     + strlen(name)
@@ -457,9 +463,31 @@ clib_package_url(const char *author, const char *name, const char *version) {
   if (slug) {
     memset(slug, '\0', size);
     sprintf(slug
-      , "https://raw.githubusercontent.com/%s/%s/%s"
+      , GITHUB_CONTENT_URL "%s/%s/%s"
       , author
       , name
+      , version);
+  }
+  return slug;
+}
+
+char *
+clib_package_url_from_repo(const char *repo, const char *version) {
+  if (!repo || !version) return NULL;
+  int size =
+      strlen(GITHUB_CONTENT_URL)
+    + strlen(repo)
+    + 1 // /
+    + strlen(version)
+    + 1 // \0
+    ;
+
+  char *slug = malloc(size);
+  if (slug) {
+    memset(slug, '\0', size);
+    sprintf(slug
+      , GITHUB_CONTENT_URL "%s/%s"
+      , repo
       , version);
   }
   return slug;

--- a/src/clib-package.h
+++ b/src/clib-package.h
@@ -44,6 +44,9 @@ char *
 clib_package_url(const char *, const char *, const char *);
 
 char *
+clib_package_url_from_repo(const char *repo, const char *version);
+
+char *
 clib_package_parse_version(const char *);
 
 char *

--- a/test/package-new-from-slug.c
+++ b/test/package-new-from-slug.c
@@ -28,9 +28,16 @@ describe("clib_package_new_from_slug", {
   });
 
   it("should force package version numbers", {
+    clib_package_t *pkg = clib_package_new_from_slug("stephenmathieson/mkdirp.c@0.0.1", 0);
+    assert(pkg);
+    assert_str_equal("0.0.1", pkg->version);
+    clib_package_free(pkg);
+  });
+
+  it("should use package version if version not provided", {
     clib_package_t *pkg = clib_package_new_from_slug("stephenmathieson/mkdirp.c", 0);
     assert(pkg);
-    assert_str_equal("master", pkg->version);
+    assert_str_equal("0.1.5", pkg->version);
     clib_package_free(pkg);
   });
 


### PR DESCRIPTION
Fixes https://github.com/clibs/clib/issues/125

This commit uses the repo key value inside the package.json to
override the URL of which we obtain package source files. This lets us
use a repo as a proxy to obtain the source of another repo which does
not have a package.json.

With this change you can do this:
```clib install clibs/sds```

and it'll install the source code at antirez/sds as defined by this package.json (assuming package.json exists in github.com/clibs/sds):
```json
{
  "name": "sds",
  "version": "1.0.0",
  "repo": "antirez/sds",
  "description": "String library",
  "src": [
    "sds.c",
    "sds.h"
  ]
}
```